### PR TITLE
Fix: Bug with commas in function/action params

### DIFF
--- a/src/parser/cds.lalrpop
+++ b/src/parser/cds.lalrpop
@@ -188,7 +188,7 @@ Params: Vec<Box<dyn ASTTerm>> = {
         params.push(param);
         params
     },
-    <params:Params> <param:Param> => {
+    <params:Params> "," <param:Param> => {
         let mut new_params: Vec<Box<dyn ASTTerm>> = Vec::new();
         new_params.extend(params);
         new_params.push(param);

--- a/tests/util/files/mockdata/positive/functions-and-actions/expectedIR.json
+++ b/tests/util/files/mockdata/positive/functions-and-actions/expectedIR.json
@@ -36,7 +36,7 @@
       "entities": [],
       "functions": [
         {
-          "name": "ftest0",
+          "name": "ftest1",
           "params": [],
           "output": {
             "type": "Test",
@@ -55,14 +55,14 @@
             "type": "Test",
             "isArrayed": false
           },
-          "name": "ftest1"
+          "name": "ftest2"
         },
         {
           "output": {
             "type": "Test",
             "isArrayed": false
           },
-          "name": "ftest2",
+          "name": "ftest3",
           "params": [
             {
               "name": "arg1",
@@ -81,7 +81,7 @@
             "type": "Test",
             "isArrayed": false
           },
-          "name": "ftest3",
+          "name": "ftest4",
           "params": [
             {
               "name": "arg1",

--- a/tests/util/files/mockdata/positive/functions-and-actions/expectedIR.json
+++ b/tests/util/files/mockdata/positive/functions-and-actions/expectedIR.json
@@ -55,14 +55,14 @@
             "type": "Test",
             "isArrayed": false
           },
-          "name": "ftest0"
+          "name": "ftest1"
         },
         {
           "output": {
             "type": "Test",
             "isArrayed": false
           },
-          "name": "ftest0",
+          "name": "ftest2",
           "params": [
             {
               "name": "arg1",
@@ -73,6 +73,30 @@
               "name": "arg2",
               "isArrayed": false,
               "type": "Test2"
+            }
+          ]
+        },
+        {
+          "output": {
+            "type": "Test",
+            "isArrayed": false
+          },
+          "name": "ftest3",
+          "params": [
+            {
+              "name": "arg1",
+              "type": "Test",
+              "isArrayed": false
+            },
+            {
+              "name": "arg2",
+              "isArrayed": false,
+              "type": "Test2"
+            },
+            {
+              "name": "arg3",
+              "isArrayed": false,
+              "type": "Test3"
             }
           ]
         }

--- a/tests/util/files/mockdata/positive/functions-and-actions/expectedIR.json
+++ b/tests/util/files/mockdata/positive/functions-and-actions/expectedIR.json
@@ -1,0 +1,82 @@
+{
+  "entities": [],
+  "types": [],
+  "services": [
+    {
+      "name": "TestService",
+      "actions": [
+        {
+          "params": [
+            {
+              "type": "Test",
+              "isArrayed": false,
+              "name": "arg1"
+            }
+          ],
+          "hasOutput": false,
+          "name": "atest1"
+        },
+        {
+          "params": [
+            {
+              "name": "arg1",
+              "isArrayed": false,
+              "type": "Test"
+            },
+            {
+              "name": "arg2",
+              "type": "Test",
+              "isArrayed": false
+            }
+          ],
+          "name": "atest",
+          "hasOutput": false
+        }
+      ],
+      "entities": [],
+      "functions": [
+        {
+          "name": "ftest0",
+          "params": [],
+          "output": {
+            "type": "Test",
+            "isArrayed": false
+          }
+        },
+        {
+          "params": [
+            {
+              "isArrayed": false,
+              "name": "arg1",
+              "type": "Test"
+            }
+          ],
+          "output": {
+            "type": "Test",
+            "isArrayed": false
+          },
+          "name": "ftest0"
+        },
+        {
+          "output": {
+            "type": "Test",
+            "isArrayed": false
+          },
+          "name": "ftest0",
+          "params": [
+            {
+              "name": "arg1",
+              "type": "Test",
+              "isArrayed": false
+            },
+            {
+              "name": "arg2",
+              "isArrayed": false,
+              "type": "Test2"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/util/files/mockdata/positive/functions-and-actions/index.cds
+++ b/tests/util/files/mockdata/positive/functions-and-actions/index.cds
@@ -1,0 +1,8 @@
+service TestService {
+    action atest1(arg1: Test);
+    action atest(arg1: Test, arg2: Test);
+
+    function ftest0() returns Test;
+    function ftest0(arg1: Test) returns Test;
+    function ftest0(arg1: Test, arg2: Test2) returns Test;
+}

--- a/tests/util/files/mockdata/positive/functions-and-actions/index.cds
+++ b/tests/util/files/mockdata/positive/functions-and-actions/index.cds
@@ -2,7 +2,8 @@ service TestService {
     action atest1(arg1: Test);
     action atest(arg1: Test, arg2: Test);
 
-    function ftest0() returns Test;
-    function ftest0(arg1: Test) returns Test;
-    function ftest0(arg1: Test, arg2: Test2) returns Test;
+    function ftest1() returns Test;
+    function ftest2(arg1: Test) returns Test;
+    function ftest3(arg1: Test, arg2: Test2) returns Test;
+    function ftest4(arg1: Test, arg2: Test2, arg3: Test3) returns Test;
 }


### PR DESCRIPTION
Fixed a bug in commas in the accepted syntax:
Before
```
function test(param1: Type1 param2: Type2) returns Test;
```
After
```
function test(param1: Type1, param2: Type2) returns Test;
```